### PR TITLE
Fix element-api options

### DIFF
--- a/views/stoplight.handlebars
+++ b/views/stoplight.handlebars
@@ -21,7 +21,8 @@
       apiDescriptionDocument='{{data.document}}'
       {{#if data.router}}router='{{data.router}}'{{/if}}
       {{#if data.layout}}layout='{{data.layout}}'{{/if}}
-      {{#if data.hideInternal}}basePath='{{data.hideTryIt}}'{{/if}}
+      {{#if data.basePath}}basePath='{{data.basePath}}'{{/if}}
+      {{#if data.hideInternal}}hideInternal='{{data.hideInternal}}'{{/if}}
       {{#if data.hideTryIt}}hideTryIt='{{data.hideTryIt}}'{{/if}}
       {{#if data.tryItCorsProxy}}tryItCorsProxy='{{data.tryItCorsProxy}}'{{/if}}
       {{#if data.logo}}logo='{{data.logo}}'{{/if}}


### PR DESCRIPTION
Hi there! Thank you for your package, it's a very nice replacement of the default swagger UI 🙏 

I found an issue in the options passed to the `<element-api>` tag where `hideInternal` and `basePath` are not taken into account and this PR fixes that